### PR TITLE
Streamline the bundle size by removing unused bindings

### DIFF
--- a/crates/tracel-mlir-sys/wrapper.h
+++ b/crates/tracel-mlir-sys/wrapper.h
@@ -1,44 +1,44 @@
-#include <mlir-c/AffineExpr.h>
-#include <mlir-c/AffineMap.h>
+// #include <mlir-c/AffineExpr.h>
+// #include <mlir-c/AffineMap.h>
 #include <mlir-c/BuiltinAttributes.h>
 #include <mlir-c/BuiltinTypes.h>
 #include <mlir-c/Conversion.h>
-#include <mlir-c/Debug.h>
+// #include <mlir-c/Debug.h>
 #include <mlir-c/Diagnostics.h>
-#include <mlir-c/Dialect/AMDGPU.h>
-#include <mlir-c/Dialect/Arith.h>
+// #include <mlir-c/Dialect/AMDGPU.h>
+// #include <mlir-c/Dialect/Arith.h>
 #include <mlir-c/Dialect/Async.h>
 #include <mlir-c/Dialect/ControlFlow.h>
-#include <mlir-c/Dialect/EmitC.h>
+// #include <mlir-c/Dialect/EmitC.h>
 #include <mlir-c/Dialect/Func.h>
 #include <mlir-c/Dialect/GPU.h>
 #include <mlir-c/Dialect/IRDL.h>
 #include <mlir-c/Dialect/LLVM.h>
 #include <mlir-c/Dialect/Linalg.h>
-#include <mlir-c/Dialect/MLProgram.h>
-#include <mlir-c/Dialect/Math.h>
-#include <mlir-c/Dialect/MemRef.h>
+// #include <mlir-c/Dialect/MLProgram.h>
+// #include <mlir-c/Dialect/Math.h>
+// #include <mlir-c/Dialect/MemRef.h>
 #include <mlir-c/Dialect/NVGPU.h>
-#include <mlir-c/Dialect/NVVM.h>
-#include <mlir-c/Dialect/OpenMP.h>
+// #include <mlir-c/Dialect/NVVM.h>
+// #include <mlir-c/Dialect/OpenMP.h>
 #include <mlir-c/Dialect/PDL.h>
 #include <mlir-c/Dialect/Quant.h>
-#include <mlir-c/Dialect/ROCDL.h>
+// #include <mlir-c/Dialect/ROCDL.h>
 #include <mlir-c/Dialect/SCF.h>
-#include <mlir-c/Dialect/SPIRV.h>
+// #include <mlir-c/Dialect/SPIRV.h>
 #include <mlir-c/Dialect/Shape.h>
 #include <mlir-c/Dialect/SparseTensor.h>
 #include <mlir-c/Dialect/Tensor.h>
 #include <mlir-c/Dialect/Transform.h>
-#include <mlir-c/Dialect/Transform/Interpreter.h>
-#include <mlir-c/Dialect/Vector.h>
+// #include <mlir-c/Dialect/Transform/Interpreter.h>
+// #include <mlir-c/Dialect/Vector.h>
 #include <mlir-c/ExecutionEngine.h>
-#include <mlir-c/IR.h>
-#include <mlir-c/IntegerSet.h>
-#include <mlir-c/Interfaces.h>
-#include <mlir-c/Pass.h>
+// #include <mlir-c/IR.h>
+// #include <mlir-c/IntegerSet.h>
+// #include <mlir-c/Interfaces.h>
+// #include <mlir-c/Pass.h>
 #include <mlir-c/RegisterEverything.h>
-#include <mlir-c/Rewrite.h>
-#include <mlir-c/Support.h>
-#include <mlir-c/Target/LLVMIR.h>
+// #include <mlir-c/Rewrite.h>
+// #include <mlir-c/Support.h>
+// #include <mlir-c/Target/LLVMIR.h>
 #include <mlir-c/Transforms.h>


### PR DESCRIPTION
This PR streamlines the MLIR binding bundle by removing unused includes from crates/tracel-mlir-sys/wrapper.h.

✅ Verified locally that both tracel-llvm and cubecl build successfully after these changes.

This reduces build size and improves clarity while keeping all required headers for CubeCL.

Removed (commented out): SPIRV, ROCDL, OpenMP, NVVM, Math, MemRef, AMDGPU, EmitC, Vector, etc.
Kept: BuiltinAttributes, BuiltinTypes, Func, GPU, Linalg, SCF, Shape, Tensor, Transform, ExecutionEngine, Diagnostics, IRDL, Quant, etc.

Fixes #3