### PR TITLE
fix: removed unused runtime dependency on `reqwest`

### DIFF
--- a/crates/tracel-llvm-bundler/Cargo.toml
+++ b/crates/tracel-llvm-bundler/Cargo.toml
@@ -20,7 +20,6 @@ constcat = "0.6.1"
 dirs = { version = "6.0" }
 liblzma = { version = "0.4.4", features = ["static", "parallel"] }
 regex = "1.11.2"
-reqwest = { version = "0.12.23", features = ["blocking", "rustls-tls", "http2"], default-features = false }
 sha2 = "0.10.9"
 tar = { version = "0.4" }
 walkdir = "2.5.0"


### PR DESCRIPTION
When using `cubecl-cpu`, I notice that `tracel-llvm-bundler` adds `reqwest` to the tree. This in turn pulls in a lot of very opinionated and bulky stuff: `futures`, `hyper`, `tokio`, `tower`, TLS stuff, so forth. At its core, it felt strange for an entire fully featured HTTP client to be added just to run some kernels on the CPU, so I went digging!

Curiously, `cargo +nightly udeps` doesn't detect any superfluous dependencies. OTOH, in `tracel-llvm-bundler`, a quick `grep` confirms that the term `reqwest` appears in three locations:
- `build.rs`: To download LLVM - so far, so good.
```rust
fn download_to_path(url: &str, dest: &Path) -> AnyResult<()> {
    let client = reqwest::blocking::Client::builder()
        .timeout(Duration::from_secs(60 * 5))
        .build()?;
    let mut resp = client.get(url).send()?.error_for_status()?;
    if let Some(parent) = dest.parent() {
        create_dir_all(parent)?;
    }
    let mut f = File::create(dest)?;
    std::io::copy(&mut resp, &mut f)?;
    Ok(())
}
```

- `Cargo.toml`: Twice; once in the build dependencies, once in the runtime dependencies.

As far as I can tell, `reqwest` is never actually used at runtime; LLVM is downloaded and embedded entirely at build-time, making `reqwest` not needed at runtime. I ran `cargo check` and `cargo xtask check` against the entire workspace after the change, and everything seems fine - it's no rigorous test, but I figured a quick PR was warranted.

Hope this helps! -Sof